### PR TITLE
Relax regex for checking output filename

### DIFF
--- a/kmc_tools/parser.cpp
+++ b/kmc_tools/parser.cpp
@@ -29,7 +29,7 @@ CParser::CParser(const std::string& src):
 		exit(1);
 	}
 	//input_line_pattern = "\\s*(\\w*)\\s*=\\s*(.*)$";
-	input_line_pattern = "^\\s*([\\w-+]*)\\s*=\\s*(.*)$"; //TODO: consider valid file name	
+	input_line_pattern = "^\\s*(.*)\\s*=\\s*(.*)$"; //TODO: consider valid file name	
 	empty_line_pattern = "^\\s*$";
 }
 


### PR DESCRIPTION
Relax regex for checking output filename to allow non [A-Za-z0-9_] chars such as directory separators. 